### PR TITLE
Fixed #119

### DIFF
--- a/conf/executors/base.config
+++ b/conf/executors/base.config
@@ -37,7 +37,7 @@ process {
 
 params {
   // Defaults only, expecting to be overwritten
-  max_memory = 128.GB
+  max_memory = 80.GB
   max_cpus = 16
   max_time = 240.h
 }

--- a/conf/executors/sumner.config
+++ b/conf/executors/sumner.config
@@ -49,7 +49,7 @@ process {
     }
     withName: 'star' {
         cpus = 24
-        memory = 80.GB
+        memory = { params.max_memory }
     }
     withName: 'stringtie' {
         cpus = 8


### PR DESCRIPTION
This PR:
- Changes the STAR process memory on Sumner from 80.GB (which is still the default value) -> the `max_memory` parameter
- As `--max_memory` is a parameter this is variable and so can be increased by the user when running a job with large FASTQ input data for example

This turned out to be a pretty simple fix. 

## Usage
To modify the STAR process memory try adding this to your `config`, for example:
```groovy
params {
  max_memory = 128.GB
}
```