### PR TITLE
Fixed #138 to correctly process read from SRA/GTEx

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -249,10 +249,11 @@ if ( download_from('gtex') || download_from('sra') ) {
     each file(key_file) from key_file
     
     output:
-    set val(accession), file("*.fastq.gz") into raw_reads_fastqc, raw_reads_trimmomatic
+    set val(accession), file(output_filename) into raw_reads_fastqc, raw_reads_trimmomatic
 
     script:
     def vdbConfigCmd = key_file.name != 'no_key_file.txt' ? "vdb-config --import ${key_file} ./" : ''
+    output_filename = params.singleEnd ? "${accession}.fastq.gz" : "${accession}_{1,2}.fastq.gz"
     """
     $vdbConfigCmd
     fasterq-dump $accession --threads ${task.cpus} --split-3


### PR DESCRIPTION
This PR should fix bug #138 
- By correctly outputting either paired or single-end reads from the `get_accession` process based on the value of the `singleEnd` parameter