### PR TITLE
Added check for paired vs single-end BAMs from TCGA

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -280,8 +280,6 @@ if ( download_from('gtex') || download_from('sra') ) {
 if (download_from('tcga')) {
   process get_tcga_bams {
     tag "${accession}"
-    publishDir "${params.outdir}/QC/tcga", mode: 'copy',
-      saveAs: {filename -> filename == "${accession}_paired_info.csv" ? null : "$filename"}
     
     input:
     val(accession) from accession_ids
@@ -289,6 +287,7 @@ if (download_from('tcga')) {
     
     output:
     set val(accession), file("*.bam"), env(singleEnd) into bamtofastq
+    file("${accession}_paired_info.csv") into paired_info
 
     script:
     // TODO: improve download speed by using `-n N_CONNECTIONS`
@@ -311,6 +310,9 @@ if (download_from('tcga')) {
     echo "$accession,\$n_single_reads,\$n_paired_reads,\$singleEnd" >> ${accession}_paired_info.csv
     """
   }
+
+  paired_info
+    .collectFile(name: "${params.outdir}/QC/tcga/paired_info.csv", keepHeader: true, skip: 1)
 }
 
 /*--------------------------------------------------


### PR DESCRIPTION
This PR adds a check for single vs paired-end TCGA BAM files as per #125 
- For each TCGA BAM file, samtools will be used to check the number of paired and single-end reads
    - If the number of single-end reads > the number of paired-end reads then `singleEnd` will be set to `true`
    - The sampled ID, number of paired-end reads, single-end reads and value of `singleEnd` will be output to a CSV file (see example screenshot), one sample per line
- The `singleEnd` value will be passed to the following processes up to star
    - This will be used to treat each sample appropriately based on whether it is paired or single-end

![image](https://user-images.githubusercontent.com/32334279/86942212-c9704c80-c13c-11ea-8666-22dc89c2b3a6.png)