### PR TITLE
Fixed singleEnd check for TCGA bams

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -336,6 +336,7 @@ if (download_from('tcga')) {
     set val(name), file("*.fastq.gz"), val(singleEnd) into raw_reads_fastqc, raw_reads_trimmomatic
 
     script:
+    singleEnd=singleEnd.toBoolean()
     if (singleEnd) {
       """
       bedtools bamtofastq -i $bam -fq ${name}.fastq


### PR DESCRIPTION
This should fix the bug where TCGA paired-end reads where not being correctly analysed as paired-end reads

Although the BAMs were correctly checked if they were single vs paired-end this was exported into Nextflow as a string and not a boolean. I.e. `singleEnd` was being set as `"false"` and not `false`. This meant that when it was checked if `singleEnd` was true, as it was a string which was present this would always evaluate to `true`

I.e. previously it was always like this:
```groovy
singleEnd = 'false'
  if (singleEnd) {
    // Will always run this code block
  } else {
    // Will never run this code block
  }
``` 

Now it will be like this and should correctly check if paired vs single-end
```groovy
singleEnd = false
  if (singleEnd) {
    // Will run this code block if singleEnd is true
  } else {
    // Will now run this code block
  }
``` 