### PR TITLE
Solves rMATS uneven input

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -667,7 +667,7 @@ if (!params.test) {
         b2_flag = ''
         b2_config_cmd = ''
       } else {
-        b1_bams = b1_bams.join(",")
+        b1_bams = bams.join(",")
         b2_bams = b2_bams.join(",")
         b2_cmd = "echo $b2_bams > b2.txt"
         b2_flag = "--b2 b2.txt"


### PR DESCRIPTION
This PR solves the issue #170  

## Problem

When there are uneven number of samples in two groups in `rmats_pairs.txt` not able to segregate properly into `b1.txt` and `b2.txt`. Example - 

#### rmats_pairs.txt
```txt
test1 sample1,sample2,sample3 sample4,sample5,sample6,sample7
```
#### b1.txt
```txt
sample1,sample2,sample3
```

#### b2.txt
```txt
sample4,sample5,sample6
```

## Solution 

This was happening because the program was assuming `rmats_pairs.txt` have equal number of samples in both groups. But now, we have changed it and it should be able to handle uneven number of samples in b1 and b2 groups. Example - 

#### b1.txt
```txt
sample1,sample2,sample3
```

#### b2.txt
```txt
sample4,sample5,sample6,sample7
```

## Test

After the changes done we have [tested this in CloudOS](https://cloudos.lifebit.ai/public/jobs/5f243b11a79ea3011238492c) with 7 samples earlier generated BAM file. It able to separate uneven number of samples to both the files.