### PR TITLE
Get tool versions in results directory

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -82,6 +82,12 @@ process {
   withName: 'paired_rmats' {
     container = 'gcr.io/nextflow-250616/rmats:4.1.0'
   }
+  withName: 'collect_tool_versions_env1' {
+    container = 'gcr.io/nextflow-250616/splicing-pipelines-nf:gawk'
+  }
+  withName: 'collect_tool_versions_env2' {
+    container = 'gcr.io/nextflow-250616/rmats:4.1.0'
+  }
 }
 
 profiles {


### PR DESCRIPTION
This collects tool versions in a single file and send it to results directory - 

```
fastqc                    0.11.9                        0    bioconda
trimmomatic               0.39                          1    bioconda
star                      2.7.3a                        0    bioconda
samtools                  1.10                 h9402c20_2    bioconda
deeptoolsintervals        0.1.9            py37h8f50634_1    bioconda
multiqc                   1.8                        py_2    bioconda
gffread                   0.11.7               h8b12597_0    bioconda
stringtie  		2.1.3b
rmats                     4.1.0            py37hec4d311_0    bioconda
```

Example run - https://cloudos.lifebit.ai/public/jobs/609a7399f60d69019ae59d36

![image](https://user-images.githubusercontent.com/23085664/117814815-6f6f7480-b282-11eb-8705-e1eef40ce328.png)
