### PR TITLE
Collect script commands and additional pipeline run info

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -49,6 +49,7 @@ params {
     multiqc_config = "$baseDir/examples/assets/multiqc_config.yaml" 
     help           = false
     mega_time      = 20.h
+    tracedir = "${params.outdir}/pipeline_info"
 
     // Max resources
     max_memory     = 760.GB
@@ -98,8 +99,20 @@ profiles {
   ultra_quick_test { includeConfig 'conf/examples/ultra_quick_test.config' }
 }
 
+dag {
+  enabled = true
+  file = "${params.tracedir}/pipeline_dag.svg"
+}
+report {
+  enabled = true
+  file = "${params.tracedir}/execution_report.html"
+}
+timeline {
+  enabled = true
+  file = "${params.tracedir}/execution_timeline.html"
+}
 trace {
   enabled = true
-  file = "${params.outdir}/pipeline_info/process_scripts_trace.txt"
+  file = "${params.tracedir}/execution_trace.txt"
   fields = 'process,tag,name,status,exit,script'
 }


### PR DESCRIPTION
For #216 

And for other pipeline run related information, they now can be found in a single report under `results/pipeline_info` - Example run - https://cloudos.lifebit.ai/public/jobs/609a455ef60d69019ae553f8

This will generate a trace file something like this, which will contain all the commands - 

```
process	tag	name	status	exit	script
    
fastqc	SRR4238355	fastqc (SRR4238355)	CACHED	0	
    fastqc --casava --threads 2 SRR4238355_subsamp.fastq.gz

    
trimmomatic	SRR4238351	trimmomatic (SRR4238351)	CACHED	0	
    trimmomatic       SE       -threads 2       -phred33       SRR4238351_subsamp.fastq.gz       SRR4238351_trimmed.fastq.gz       ILLUMINACLIP:TruSeq3-SE.fa:2:30:10       LEADING:3       TRAILING:3       SLIDINGWINDOW:4:15       MINLEN:20       CROP:48

    mkdir logs
    cp .command.log logs/SRR4238351_trimmomatic.log
    
fastqc_trimmed	SRR4238355	fastqc_trimmed (SRR4238355)	CACHED	0	
    fastqc --casava --threads 2 SRR4238355_trimmed.fastq.gz
    
star	SRR4238355	star (SRR4238355)	CACHED	0	
    

    # Decompress STAR index if compressed
    if [[ star.tar.gz == *.tar.gz ]]; then
      tar -xvzf star.tar.gz
    fi

    STAR       --genomeDir star       --readFilesIn SRR4238355_trimmed.fastq.gz       --readMatesLengthsIn NotEqual       --outFileNamePrefix SRR4238355.       --runThreadN 2       --readFilesCommand zcat       --sjdbGTFfile genes.gtf       --sjdbOverhang 100       --alignSJDBoverhangMin 3       --outFilterScoreMinOverLread 0.66       --outFilterMatchNminOverLread 0.66       --outFilterMismatchNmax 2       --outFilterMultimapNmax 20       --alignMatesGapMax 1000000       --outSAMattributes All       --outSAMtype BAM SortedByCoordinate       --limitBAMsortRAM 4442450944       --outBAMsortingThreadN 2       --outFilterType BySJout       --twopassMode Basic       --alignEndsType EndToEnd       --alignIntronMax 1000000       --outReadsUnmapped Fastx       --outWigType None  

    chmod a+rw SRR4238355*
    samtools view -h SRR4238355.Aligned.sortedByCoord.out.bam | gawk -v strType=2 -f /usr/local/bin/tagXSstrandedData.awk | samtools view -bS - > Aligned.XS.bam && mv Aligned.XS.bam SRR4238355.Aligned.sortedByCoord.out.bam
    samtools index SRR4238355.Aligned.sortedByCoord.out.bam
    bamCoverage -b SRR4238355.Aligned.sortedByCoord.out.bam -o SRR4238355.bw 
    
    
    
multiqc	-	multiqc (1)	CACHED	0	
    multiqc . --config multiqc_config.yaml -m fastqc -m star
    cp multiqc_report.html 05-10-21_multiqc_report.html
```