### PR TITLE
Adds singularity check in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,14 @@ name: splicing-pipelines-nf CI
 on: [push, pull_request]
 
 jobs:
-  test:
+  docker:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container_type: [docker, singularity]
         nxf_ver: ['19.04.0', '']
         max_retries: [1, 10]
     steps:
       - uses: actions/checkout@v1
-      - uses: eWaterCycle/setup-singularity@v6
-        with:
-          singularity-version: '3.6.4'
       - name: Install Nextflow
         run: |
           export NXF_VER=${{ matrix.nxf_ver }}
@@ -22,4 +18,24 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Basic workflow tests
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --max_retries ${{ matrix.max_retries }} -profile base,ultra_quick_test,${{ matrix.container_type}}
+          nextflow run ${GITHUB_WORKSPACE} --max_retries ${{ matrix.max_retries }} -profile base,ultra_quick_test,docker
+  singularity:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        singularity_version: ['3.6.4']
+        nxf_ver: ['19.04.0', '']
+        max_retries: [1, 10]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: eWaterCycle/setup-singularity@v6
+        with:
+          singularity-version: ${{ matrix.singularity_version }}
+      - name: Install Nextflow
+        run: |
+          export NXF_VER=${{ matrix.nxf_ver }}
+          wget -qO- get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+      - name: Basic workflow tests
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} --max_retries ${{ matrix.max_retries }} -profile base,ultra_quick_test,singularity


### PR DESCRIPTION
## Overview

This PR adds a set singularity step to be able to test singularity mode of the Nextflow execution in the ci.yml with github actions.

## Context

The setup singularity action example was found here:

https://github.com/marketplace/actions/setup-singularity

The assumption is that before installing Nextflow, we also setup Singularity to be able to test all container engines in the ci and ensure the merges are not breaking functionality for any mode of execution.

The snippet added can be found in the docs above, 

```bash
steps:
- uses: actions/checkout@v2
- uses: eWaterCycle/setup-singularity@v6
  with:
    singularity-version: 3.6.4
```