### PR TITLE
Reduces ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         nxf_ver: ['20.01.0', '']
-        max_retries: [1]
     steps:
       - uses: actions/checkout@v1
       - name: Install Nextflow
@@ -18,14 +17,13 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Basic workflow tests
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --max_retries ${{ matrix.max_retries }} -profile base,ultra_quick_test,docker
+          nextflow run ${GITHUB_WORKSPACE} -profile base,ultra_quick_test,docker
   singularity:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         singularity_version: ['3.6.4']
         nxf_ver: ['20.01.0', '']
-        max_retries: [1]
     steps:
       - uses: actions/checkout@v1
       - uses: eWaterCycle/setup-singularity@v6
@@ -38,4 +36,4 @@ jobs:
           sudo mv nextflow /usr/local/bin/
       - name: Basic workflow tests
         run: |
-          nextflow run ${GITHUB_WORKSPACE} --max_retries ${{ matrix.max_retries }} -profile base,ultra_quick_test,singularity
+          nextflow run ${GITHUB_WORKSPACE} -profile base,ultra_quick_test,singularity


### PR DESCRIPTION
## Description

This PR massively cuts down on CI actions (by 75%) by:
- [x] removing ci tests on `push` trigger, remains only on `pull_request`, which cuts down number of ci jobs in half. 
This is because tests run on these two triggers are the same and are always ran simultaneously on any push to a standing PR. Since we always have any work in progress in a PR, it is enough to keep `pull_request` trigger only to test any change.
- [x] removing `max_retries: [1, 10]` matrix option, which cuts down number of ci tests again in half. 
The matrix `max_retries: [1, 10]` was introduced in PR #212 to check the maxRetries option. But since it is working fine since then, there is no need to explicitly duplicate all the ci tests to run pipeline just to test different `maxRetries` values.

Additionally
- [x] Tis PR updates ci test fixed nf version to the current one used on cloudos.lifebit.ai: `19.04.0` -> `20.01.0`