### PR TITLE
Updates all tools and moves docker containers to anczukowlab repo

### DIFF
--- a/conf/examples/ultra_quick_test.config
+++ b/conf/examples/ultra_quick_test.config
@@ -15,7 +15,7 @@ params {
 
   // Genome references
   gtf = 'https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/genes.gtf'
-  star_index = 'https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/star.tar.gz'
+  star_index = 'https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/star_2.7.9a_yeast_chr_I.tar.gz'
 
   // Other
   test = true

--- a/containers/download_reads/environment.yml
+++ b/containers/download_reads/environment.yml
@@ -5,8 +5,8 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - sra-tools=2.10.8
-  - pigz=2.3.4
-  - gdc-client=1.5.0
-  - samtools=1.10
-  - bedtools=2.29.2
+  - sra-tools=2.11.0
+  - pigz=2.6.0
+  - gdc-client=1.6.1
+  - samtools=1.13
+  - bedtools=2.30.0

--- a/containers/fasp/Dockerfile
+++ b/containers/fasp/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
   && cd fasp-scripts \
   && python setup.py install \
   && chmod +x fasp/scripts/* \
-  && conda install samtools=1.11 -c bioconda -c conda-forge \
+  && conda install samtools=1.13 -c bioconda -c conda-forge \
   && conda clean -a
   
 ENV PATH /fasp-scripts/fasp/scripts:$PATH

--- a/containers/splicing-pipelines-nf/Dockerfile
+++ b/containers/splicing-pipelines-nf/Dockerfile
@@ -9,12 +9,15 @@ ENV PATH /opt/conda/envs/splicing-pipelines-nf/bin:$PATH
 COPY ./tagXSstrandedData.awk /usr/local/bin/
 RUN chmod +x /usr/local/bin/tagXSstrandedData.awk
 
-# Install the latest stringtie & gffcompare
-RUN wget http://ccb.jhu.edu/software/stringtie/dl/stringtie-2.1.3b.Linux_x86_64.tar.gz -O stringtie.tar.gz && \
-    tar xvzf stringtie.tar.gz && mv stringtie-2.1.3b.Linux_x86_64 stringtie && \
+# Install the latest stringtie, gffread & gffcompare
+RUN wget http://ccb.jhu.edu/software/stringtie/dl/stringtie-2.1.7.Linux_x86_64.tar.gz -O stringtie.tar.gz && \
+    tar xvzf stringtie.tar.gz && mv stringtie-2.1.7.Linux_x86_64 stringtie && \
     rm stringtie.tar.gz && mv stringtie/prepDE.py stringtie/stringtie /usr/local/bin && \
-    wget http://ccb.jhu.edu/software/stringtie/dl/gffcompare-0.11.6.Linux_x86_64.tar.gz -O gffcompare.tar.gz && \
-    tar xvzf gffcompare.tar.gz && mv gffcompare-0.11.6.Linux_x86_64 gffcompare && \
+    wget http://ccb.jhu.edu/software/stringtie/dl/gffread-0.12.7.Linux_x86_64.tar.gz -O gffread.tar.gz && \
+    tar xvzf gffread.tar.gz && mv gffread-0.12.7.Linux_x86_64 gffread && \
+    rm gffread.tar.gz && mv gffread/gffread /usr/local/bin/ && \
+    wget http://ccb.jhu.edu/software/stringtie/dl/gffcompare-0.12.6.Linux_x86_64.tar.gz -O gffcompare.tar.gz && \
+    tar xvzf gffcompare.tar.gz && mv gffcompare-0.12.6.Linux_x86_64 gffcompare && \
     rm gffcompare.tar.gz && mv gffcompare/gffcompare gffcompare/trmap /usr/local/bin/
 # Install gawk to fix https://github.com/TheJacksonLaboratory/splicing-pipelines-nf/issues/120
 RUN apt-get install -y gawk

--- a/containers/splicing-pipelines-nf/environment.yml
+++ b/containers/splicing-pipelines-nf/environment.yml
@@ -6,13 +6,13 @@ channels:
 dependencies:
   - fastqc=0.11.9
   - trimmomatic=0.39
-  - star=2.7.3
-  - samtools=1.10
-  - deeptools=3.4.0
-  - multiqc=1.8
-  - gffread=0.11.7
-  - bioconductor-rtracklayer=1.46.0
+  - star=2.7.9a
+  - samtools=1.13
+  - deeptools=3.5.1
+  - multiqc=1.11
+  - bioconductor-rtracklayer=1.52.0
 
 # Now installed via executable in `Dockerfile`
-  # - stringtie=2.1.2
-  # - gffcompare=0.11.2
+  # - stringtie=2.1.7
+  # - gffread=0.12.7 (version not available on conda)
+  # - gffcompare=0.12.6

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,30 +69,30 @@ cleanup = params.cleanup
 
 process {
   errorStrategy = 'finish'
-  container = 'gcr.io/nextflow-250616/splicing-pipelines-nf:gawk'
+  container = 'anczukowlab/splicing-pipelines-nf:3.0'
   withName: 'get_accession' {
-    container = 'lifebitai/download_reads:latest'
+    container = 'anczukowlab/download_reads:2.0'
   }
   withName: 'gen3_drs_fasp' {
-    container = 'quay.io/lifebitai/lifebit-ai-fasp:latest'
+    container = 'anczukowlab/lifebit-ai-fasp:v1.1'
   }
   withName: 'get_tcga_bams' {
-    container = 'lifebitai/download_reads:latest'
+    container = 'anczukowlab/download_reads:2.0'
   }
   withName: 'bamtofastq' {
-    container = 'lifebitai/download_reads:latest'
+    container = 'anczukowlab/download_reads:2.0'
   }
   withName: 'rmats' {
-    container = 'lifebitai/splicing-rmats:4.1.1'
+    container = 'anczukowlab/splicing-rmats:4.1.1'
   }
   withName: 'paired_rmats' {
-    container = 'lifebitai/splicing-rmats:4.1.1'
+    container = 'anczukowlab/splicing-rmats:4.1.1'
   }
   withName: 'collect_tool_versions_env1' {
-    container = 'gcr.io/nextflow-250616/splicing-pipelines-nf:gawk'
+    container = 'anczukowlab/splicing-pipelines-nf:3.0'
   }
   withName: 'collect_tool_versions_env2' {
-    container = 'lifebitai/splicing-rmats:4.1.1'
+    container = 'anczukowlab/splicing-rmats:4.1.1'
   }
 }
 


### PR DESCRIPTION
## Description
Current updates almost all tool version used in the pipelines and moves all docker containers to [dockerhub/anczukowlab](https://hub.docker.com/r/anczukowlab) repository.

### Solves issues: 
- resolves #233 
- resolves #234
- resolves #235
- resolves #249
- resolves #236 

## Updates:
- [x] **STAR** `2.7.3` -> `2.7.9a`
- [x] **Samtools** `1.10` -> `1.13`
- [x] **StringTie** `2.7.3` -> `2.7.9a`
- [x] **Gffread** `0.11.7` -> `0.12.7`
- [x] multiqc `1.8` -> `1.11`
- [x] deeptools `3.4.0` -> `3.5.1`
- [x] bioconductor-rtracklayer `1.46.0` -> `1.52.0`
- [x] gffcompare `0.11.2` -> `0.12.6`
- [x] bedtools `2.29.2` -> `2.30.0`
- [x] sra-tools `2.10.8` -> `2.11.0`
- [x] pigz `2.3.4` -> `2.6.0`
- [x] gdc-client `1.5.0` -> `1.6.1`

## Moves all containers to [anczukowlab dockerhub account](https://hub.docker.com/search?q=anczukowlab&type=image):
- [x] [gcr.io/nextflow-250616/splicing-pipelines-nf](https://console.cloud.google.com/gcr/images/nextflow-250616/GLOBAL/splicing-pipelines-nf?gcrImageListsize=30) -> [anczukowlab/splicing-pipelines-nf](https://hub.docker.com/r/anczukowlab/splicing-pipelines-nf/tags?page=1&ordering=last_updated)
- [x] [lifebitai/download_reads](https://hub.docker.com/r/lifebitai/download_reads) -> [anczukowlab/download_reads](https://hub.docker.com/r/anczukowlab/download_reads)
- [x] [quay.io/lifebitai/lifebit-ai-fasp](https://quay.io/repository/lifebitai/lifebit-ai-fasp?tag=latest&tab=tags) ->  [anczukowlab/lifebit-ai-fasp](https://hub.docker.com/r/anczukowlab/lifebit-ai-fasp)
- [x] [lifebitai/splicing-rmats](https://hub.docker.com/r/lifebitai/splicing-rmats) -> https://hub.docker.com/r/anczukowlab/splicing-rmats

![image](https://user-images.githubusercontent.com/64809705/128347393-26c23e66-027a-4286-9ad3-bd9e454e0a1a.png)


## Changes
Since STAR version 2.7.4a STAR requires a new index. So all previously used STAR indices will have to be rebuilt with new version of STAR to work correctly.

The start index used for the ultra_quick_test is already rebuilt and set in profile with this PR.
All other indices will have to be updated additionally.

## Testing
Pipeline is successfully tested locally with docker and singularity options:
```
NXF_VER=20.01.0 nextflow run . -profile ultra_quick_test,docker
```
![image](https://user-images.githubusercontent.com/64809705/128346237-4359202e-9323-4471-a15e-a311bff79af5.png)
```
NXF_VER=20.01.0 nextflow run . -profile ultra_quick_test,singularity
```
![image](https://user-images.githubusercontent.com/64809705/128346978-705bf693-4f0b-4f2e-8925-95d478ed597b.png)

## To test
Pipeline still has to be tested on sumner. Also options to run pipeline with pulling data from SRA and other sources should be tested.
```
git clone https://github.com/TheJacksonLaboratory/splicing-pipelines-nf
cd splicing-pipelines-nf
git checkout vlad-updates-tools
nextflow run . -profile  ultra_quick_test,sumner
```
Other tests should be performed only after updating the STAR indices they are using. 
Command to create new star index:
```
STAR   --runMode genomeGenerate   --runThreadN 2   --genomeDir star/   --genomeFastaFiles genome.fa --sjdbGTFfile genes.gtf
```
The command above should be run using the latest version of anczukowlab/splicing-pipelines-nf container