### PR TITLE
Adds xstag strType parameter

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -977,7 +977,7 @@ if (!params.test) {
 if (!params.bams) {
   process multiqc {
     label 'mega_memory'
-    publishDir "${params.outdir}/MultiQC", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/MultiQC", pattern: "{*multiqc_report.html,*_data/*,trimmomatic}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     when:

--- a/main.nf
+++ b/main.nf
@@ -736,7 +736,7 @@ if (!params.test) {
 
   process prep_de {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "{sample_lst.txt,*gene_count_matrix.csv,*transcript_count_matrix.csv}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -179,6 +179,7 @@ log.info "Single-end                  : ${download_from('tcga') ? 'Will be check
 log.info "GTF                         : ${params.gtf}"
 log.info "STAR index                  : ${star_index}"
 log.info "Stranded                    : ${params.stranded}"
+log.info "strType                     : ${params.strType[params.stranded].strType}"
 log.info "Soft_clipping               : ${params.soft_clipping}"
 log.info "rMATS pairs file            : ${params.rmats_pairs ? params.rmats_pairs : 'Not provided'}"
 log.info "Adapter                     : ${download_from('tcga') ? 'Will be set for each sample based based on whether the sample is paired or single-end' : adapter_file}"
@@ -644,7 +645,7 @@ if (!params.bams){
     // TODO: find a better solution to needing to use `chmod`
     out_filter_intron_motifs = params.stranded ? '' : '--outFilterIntronMotifs RemoveNoncanonicalUnannotated'
     out_sam_strand_field = params.stranded ? '' : '--outSAMstrandField intronMotif'
-    xs_tag_cmd = params.stranded ? "samtools view -h ${name}.Aligned.sortedByCoord.out.bam | gawk -v strType=2 -f /usr/local/bin/tagXSstrandedData.awk | samtools view -bS - > Aligned.XS.bam && mv Aligned.XS.bam ${name}.Aligned.sortedByCoord.out.bam" : ''
+    xs_tag_cmd = params.stranded ? "samtools view -h ${name}.Aligned.sortedByCoord.out.bam | gawk -v q=${params.strType[params.stranded].strType} -f /usr/local/bin/tagXSstrandedData.awk | samtools view -bS - > Aligned.XS.bam && mv Aligned.XS.bam ${name}.Aligned.sortedByCoord.out.bam" : ''
     endsType = params.soft_clipping ? 'Local' : 'EndToEnd'
     // Set maximum available memory to be used by STAR to sort BAM files
     star_mem = params.star_memory ? params.star_memory : task.memory

--- a/main.nf
+++ b/main.nf
@@ -767,7 +767,7 @@ if (!params.test) {
 
   process stringtie_merge {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "{gffcmp.annotated.corrected.gtf,gffcmp.*}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -645,7 +645,7 @@ if (!params.bams){
     // TODO: find a better solution to needing to use `chmod`
     out_filter_intron_motifs = params.stranded ? '' : '--outFilterIntronMotifs RemoveNoncanonicalUnannotated'
     out_sam_strand_field = params.stranded ? '' : '--outSAMstrandField intronMotif'
-    xs_tag_cmd = params.stranded ? "samtools view -h ${name}.Aligned.sortedByCoord.out.bam | gawk -v q=${params.strType[params.stranded].strType} -f /usr/local/bin/tagXSstrandedData.awk | samtools view -bS - > Aligned.XS.bam && mv Aligned.XS.bam ${name}.Aligned.sortedByCoord.out.bam" : ''
+    xs_tag_cmd = params.stranded ? "samtools view -h ${name}.Aligned.sortedByCoord.out.bam | gawk -v strType=${params.strType[params.stranded].strType} -f /usr/local/bin/tagXSstrandedData.awk | samtools view -bS - > Aligned.XS.bam && mv Aligned.XS.bam ${name}.Aligned.sortedByCoord.out.bam" : ''
     endsType = params.soft_clipping ? 'Local' : 'EndToEnd'
     // Set maximum available memory to be used by STAR to sort BAM files
     star_mem = params.star_memory ? params.star_memory : task.memory

--- a/main.nf
+++ b/main.nf
@@ -741,12 +741,12 @@ if (!params.test) {
 
     input:
     file(gtf) from stringtie_dge_gtf.collect()
-    file("command-logs-*") optional true
 
     output:
     file "sample_lst.txt"
     file "*gene_count_matrix.csv"
     file "*transcript_count_matrix.csv"
+    file("command-logs-*") optional true
 
     script: 
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,14 @@ params {
     star_index     = false
     singleEnd      = false
     stranded       = 'first-strand'
+    strType {
+      'first-strand' {
+        strType = 2
+      }
+      'second-strand' {
+        strType = 1
+      }
+    }
     readlength     = false
 
     // Trimmomatic: 


### PR DESCRIPTION
Closes #201 

(PR closed without merging in favor of cleaner PR: #264 )

## This PR

Makes strType parameter in xs command (after star, in star process) to be not hardcoded as 2 but be set depending on value of `stranded` parameter.

## To test:
```
git clone https://github.com/TheJacksonLaboratory/splicing-pipelines-nf
cd splicing-pipelines-nf
git checkout add-xs-tag
```
```
# Default execution, same as if strType=2 was hardcoded
NXF_VER=20.01.0 nextflow run . -profile ultra_quick_test,docker -resume --stranded 'first-strand'
```
```
NXF_VER=20.01.0 nextflow run . -profile ultra_quick_test,docker -resume --stranded 'second-strand'
```