### PR TITLE
Fix saving files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -976,7 +976,7 @@ if (!params.test) {
 if (!params.bams) {
   process multiqc {
     label 'mega_memory'
-    publishDir "${params.outdir}/MultiQC", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/MultiQC", pattern: "{*multiqc_report.html,*_data/*,trimmomatic}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     when:

--- a/main.nf
+++ b/main.nf
@@ -735,7 +735,7 @@ if (!params.test) {
 
   process prep_de {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "{sample_lst.txt,*gene_count_matrix.csv,*transcript_count_matrix.csv}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -836,7 +836,7 @@ if (!params.test) {
     process rmats {
       tag "$rmats_id ${gtf.simpleName}"
       label 'high_memory'
-      publishDir "${params.outdir}/rMATS_out/${rmats_id}_${gtf.simpleName}", pattern: "[!command-logs-]*", mode: 'copy'
+      publishDir "${params.outdir}/rMATS_out/${rmats_id}_${gtf.simpleName}", pattern: "{*.txt,*.csv,tmp/*_read_outcomes_by_bam.txt}", mode: 'copy'
       publishDir "${params.outdir}/process-logs/${task.process}/${rmats_id}_${gtf.simpleName}", pattern: "command-logs-*", mode: 'copy'
 
       when:
@@ -848,6 +848,7 @@ if (!params.test) {
 
       output:
       file "*.{txt,csv}" into rmats_out
+      file "tmp/*_read_outcomes_by_bam.txt"
       file("command-logs-*") optional true
 
       script:
@@ -913,7 +914,7 @@ if (!params.test) {
     process paired_rmats {
       tag "$name1 $name2"
       label 'high_memory'
-      publishDir "${params.outdir}/rMATS_out/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "[!command-logs-]*", mode: 'copy'
+      publishDir "${params.outdir}/rMATS_out/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "{*.txt,*.csv,tmp/*_read_outcomes_by_bam.txt}", mode: 'copy'
       publishDir "${params.outdir}/process-logs/${task.process}/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "command-logs-*", mode: 'copy'
 
       when:
@@ -925,6 +926,7 @@ if (!params.test) {
 
       output:
       file "*.{txt,csv}" into paired_rmats_out
+      file "tmp/*_read_outcomes_by_bam.txt"
       file("command-logs-*") optional true
 
       script:

--- a/main.nf
+++ b/main.nf
@@ -740,12 +740,12 @@ if (!params.test) {
 
     input:
     file(gtf) from stringtie_dge_gtf.collect()
-    file("command-logs-*") optional true
 
     output:
     file "sample_lst.txt"
     file "*gene_count_matrix.csv"
     file "*transcript_count_matrix.csv"
+    file("command-logs-*") optional true
 
     script: 
     """

--- a/main.nf
+++ b/main.nf
@@ -766,7 +766,7 @@ if (!params.test) {
 
   process stringtie_merge {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "{gffcmp.annotated.corrected.gtf,gffcmp.*}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:


### PR DESCRIPTION
It was found that stringti_merged results folder as well as some other folders are missing all or some files. Most probably that started happening after output pattern update needed to save .command.* logs in #251 .

This PR fixes the issues.

To test:
```
git clone https://github.com/TheJacksonLaboratory/splicing-pipelines-nf
cd splicing-pipelines-nf
git fix-saving-files
NXF_VER=20.01.0 nextflow run . -profile ultra_quick_test,docker --test false
```
The job will fail on the last process, but that's expected.

Then check folders:
- `results/star_mapped/count_matrix` for `sample_lst.txt` file;
- `results/star_mapped/stringtie_merge` for all files (all were missing before);
- `results/MultiQC` for `multiqc_data` folder.