### PR TITLE
Parametrize error strategy

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -976,7 +976,7 @@ if (!params.test) {
 if (!params.bams) {
   process multiqc {
     label 'mega_memory'
-    publishDir "${params.outdir}/MultiQC", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/MultiQC", pattern: "{*multiqc_report.html,*_data/*,trimmomatic}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     when:

--- a/main.nf
+++ b/main.nf
@@ -735,7 +735,7 @@ if (!params.test) {
 
   process prep_de {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/count_matrix", pattern: "{sample_lst.txt,*gene_count_matrix.csv,*transcript_count_matrix.csv}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -836,7 +836,7 @@ if (!params.test) {
     process rmats {
       tag "$rmats_id ${gtf.simpleName}"
       label 'high_memory'
-      publishDir "${params.outdir}/rMATS_out/${rmats_id}_${gtf.simpleName}", pattern: "[!command-logs-]*", mode: 'copy'
+      publishDir "${params.outdir}/rMATS_out/${rmats_id}_${gtf.simpleName}", pattern: "{*.txt,*.csv,tmp/*_read_outcomes_by_bam.txt}", mode: 'copy'
       publishDir "${params.outdir}/process-logs/${task.process}/${rmats_id}_${gtf.simpleName}", pattern: "command-logs-*", mode: 'copy'
 
       when:
@@ -848,6 +848,7 @@ if (!params.test) {
 
       output:
       file "*.{txt,csv}" into rmats_out
+      file "tmp/*_read_outcomes_by_bam.txt"
       file("command-logs-*") optional true
 
       script:
@@ -913,7 +914,7 @@ if (!params.test) {
     process paired_rmats {
       tag "$name1 $name2"
       label 'high_memory'
-      publishDir "${params.outdir}/rMATS_out/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "[!command-logs-]*", mode: 'copy'
+      publishDir "${params.outdir}/rMATS_out/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "{*.txt,*.csv,tmp/*_read_outcomes_by_bam.txt}", mode: 'copy'
       publishDir "${params.outdir}/process-logs/${task.process}/${name1}_vs_${name2}_${gtf.simpleName}", pattern: "command-logs-*", mode: 'copy'
 
       when:
@@ -925,6 +926,7 @@ if (!params.test) {
 
       output:
       file "*.{txt,csv}" into paired_rmats_out
+      file "tmp/*_read_outcomes_by_bam.txt"
       file("command-logs-*") optional true
 
       script:

--- a/main.nf
+++ b/main.nf
@@ -740,12 +740,12 @@ if (!params.test) {
 
     input:
     file(gtf) from stringtie_dge_gtf.collect()
-    file("command-logs-*") optional true
 
     output:
     file "sample_lst.txt"
     file "*gene_count_matrix.csv"
     file "*transcript_count_matrix.csv"
+    file("command-logs-*") optional true
 
     script: 
     """

--- a/main.nf
+++ b/main.nf
@@ -116,6 +116,10 @@ def helpMessage() {
       --debug                       This option will enable echo of script execution into STDOUT with some additional 
                                     resource information (such as machine type, memory, cpu and disk space)
                                     (default: false)
+      --error_strategy              Mode of pipeline handling failed processes. Possible values: 'terminate', 'finish', 'ignore', 'retry'.
+                                    Check nextflow documnetation for detailed descriptions of each mode:
+                                    https://www.nextflow.io/docs/latest/process.html#process-page-error-strategy
+                                    (default: $params.error_strategy)
       --cleanup                     This option will enable nextflow work folder cleanup upon pipeline successfull completion.
                                     All intermediate files from nexftlow processes' workdirs will be cleared, staging folder with staged
                                     files will not be cleared.
@@ -149,6 +153,11 @@ if (!params.bams) {
   }
 }else{ 
   star_index = false 
+}
+
+// Check if error_strategy parameter has a correct value
+if (!params.allowed_error_strategies.contains(params.error_strategy)) {
+  exit 1, "Error strategy \"${params.error_strategy} is not correct. Please choose one of: ${params.allowed_error_strategies.join(", ")}."
 }
 
 // Check if user has set adapter sequence. If not set is based on the value of the singleEnd parameter
@@ -207,6 +216,7 @@ log.info "Max time                    : ${params.max_time}"
 log.info "Mega time                   : ${params.mega_time}"
 log.info "Google Cloud disk-space     : ${params.gc_disk_size}"
 log.info "Debug                       : ${params.debug}"
+log.info "Error strategy              : ${params.error_strategy}"
 log.info "Workdir cleanup             : ${params.cleanup}"
 log.info ""
 log.info "\n"

--- a/main.nf
+++ b/main.nf
@@ -766,7 +766,7 @@ if (!params.test) {
 
   process stringtie_merge {
     label 'mid_memory'
-    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "[!command-logs-]*", mode: 'copy'
+    publishDir "${params.outdir}/star_mapped/stringtie_merge", pattern: "{gffcmp.annotated.corrected.gtf,gffcmp.*}", mode: 'copy'
     publishDir "${params.outdir}/process-logs/${task.process}/", pattern: "command-logs-*", mode: 'copy'
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,8 @@ params {
     help           = false
     mega_time      = 20.h
     tracedir = "${params.outdir}/pipeline_info"
+    error_strategy = 'finish'
+    allowed_error_strategies = ['terminate', 'finish', 'ignore', 'retry']
     cleanup = false  // if true will delete all intermediate files in work folder on workflow completion (not including staged files)
 
     // Save of .command.* logs
@@ -72,7 +74,7 @@ params {
 cleanup = params.cleanup
 
 process {
-  errorStrategy = 'finish'
+  errorStrategy = params.error_strategy
   container = 'anczukowlab/splicing-pipelines-nf:3.0'
   withName: 'get_accession' {
     container = 'anczukowlab/download_reads:2.0'


### PR DESCRIPTION
## This PR
Adds a single nextflow parameter `--error_strategy` that allows to change error strategy for command line.

This was [requested](https://lifebit-biotech.slack.com/archives/G01017Z5P2P/p1631543520003600?thread_ts=1631024711.007300&cid=G01017Z5P2P) by @angarb (also see [suggested commit](https://github.com/TheJacksonLaboratory/splicing-pipelines-nf/commit/c1f55a31b208a78eb86f822257abc7cf4ee2db2e)) for the purpose of being able to easily set error strategy to "ignore" when needed to avoid pipeline failure upon one wrongful variant.

## Testing
This PR has been tested locally to be able to change error strategy from command line parameter. Testing was performed by using one correct and one corrupted fastq file created manually.
`samples_to_fail.csv`:
```
sample_id,fastq
SRR4238351,https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/reads/ultra_quick_test/SRR4238351_subsamp.fastq.gz
SRR4238355,/home/ec2-user/splicing-pipelines-nf/SRR4238355_broken.fastq.gz
```
Error strategy `ignore`:
```
nextflow run . -profile ultra_quick_test,docker --reads samples_to_fail.csv --cleanup --error_strategy 'ignore'
```
![image](https://user-images.githubusercontent.com/64809705/133387093-707da856-424f-46cf-ba99-9385b06da13e.png)

Error strategy `finish`:
```
nextflow run . -profile ultra_quick_test,docker --reads samples_to_fail.csv --cleanup --error_strategy 'finish'
```
![image](https://user-images.githubusercontent.com/64809705/133387281-12b7cb72-6b1d-47f1-8ee1-a4f40dc9c833.png)

Error strategy `terminate`:
```
nextflow run . -profile ultra_quick_test,docker --reads samples_to_fail.csv --cleanup --error_strategy 'terminate'
```
![image](https://user-images.githubusercontent.com/64809705/133387435-33198a9c-77a0-4e10-acc2-b76f7c682672.png)

Incorrect error strategy value:
```
nextflow run . -profile ultra_quick_test,docker --reads samples_to_fail.csv --cleanup --error_strategy 'ghjkvxz'
```
![image](https://user-images.githubusercontent.com/64809705/133387561-cf7e4a43-a8fa-4554-8b84-339134267e19.png)

