### PR TITLE
Fix strType issue when stranded=false

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -179,7 +179,7 @@ log.info "Single-end                  : ${download_from('tcga') ? 'Will be check
 log.info "GTF                         : ${params.gtf}"
 log.info "STAR index                  : ${star_index}"
 log.info "Stranded                    : ${params.stranded}"
-log.info "strType                     : ${params.strType[params.stranded].strType}"
+if (params.stranded) {log.info "strType                     : ${params.strType[params.stranded].strType}"}
 log.info "Soft_clipping               : ${params.soft_clipping}"
 log.info "rMATS pairs file            : ${params.rmats_pairs ? params.rmats_pairs : 'Not provided'}"
 log.info "Adapter                     : ${download_from('tcga') ? 'Will be set for each sample based based on whether the sample is paired or single-end' : adapter_file}"


### PR DESCRIPTION
Fixes issue when `params.stranded = false` (or `--stranded false`):
```
Cannot get property 'strType' on null object

 -- Check script '/projects/anczukow-lab/splicing_pipeline/splicing-pipelines-nf/main.nf' at line: 182 or see '.nextflow.log' file for more details
```

Source:
https://lifebit-biotech.slack.com/archives/D02B1UGL8JY/p1632756104002500?thread_ts=1632496920.004800&cid=D02B1UGL8JY