### PR TITLE
Fixes containers and parametrizes options in google.config

### DIFF
--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -1,9 +1,9 @@
 google {
     lifeSciences.bootDiskSize = params.gls_boot_disk_size
-    lifeSciences.preemptible = true
-    zone = 'us-east1-b'
-    network = 'jax-poc-lifebit-01-vpc-network'
-    subnetwork = 'us-east1-sub2'
+    lifeSciences.preemptible = params.gls_preemptible
+    zone = params.zone
+    network = params.network
+    subnetwork = params.subnetwork
 }
 
 docker.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -77,6 +77,10 @@ params {
     // google life science specific
     debug = false
     gls_boot_disk_size = 50.GB
+    gls_preemptible = true
+    zone = 'us-east1-b'
+    network = 'jax-poc-lifebit-01-vpc-network'
+    subnetwork = 'us-east1-sub2'
     
     // process scope options
     echo = false


### PR DESCRIPTION
## This PR
- [x] Fixes that new docker images were always overwritten by old ones when using google.config (solves #282)
- [x] Parametrizes set of google options (closes #214 )
The latter is proven by the fact that I could run this pipeline in a different workspace than it has always been run in by changing the `--network` and `--subnetwork` parameters.

## To test
```
git clone https://github.com/TheJacksonLaboratory/splicing-pipelines-nf
cd splicing-pipelines-nf
nextflow run . --reads examples/testdata/sra/sra.csv --singleEnd --download_from SRA --gtf https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/genes.gtf --star_index https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/projects/jax/splicing-pipelines-nf/star_2.7.9a_yeast_chr_I.tar.gz --test true --readlength 500 --overhang 100 --max_cpus 2 --max_memory 6.GB --max_time 48.h
```

## Successful CloudOS run
https://cloudos.lifebit.ai/app/jobs/6168145e1b866a01d698f3ca
https://cloudos.lifebit.ai/public/jobs/6168145e1b866a01d698f3ca (public)
