### PR TITLE
Change GLS executor from parameter to scope

### DIFF
--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -20,8 +20,10 @@ params {
     gc_disk_size = "2000 GB"
 
     cleanup = false // Don't change, otherwise CloudOS jobs won't be resumable by default even if user wants to.
+}
 
-    executor = 'google-lifesciences'
+executor {
+    name = 'google-lifesciences'
 }
 
 process {


### PR DESCRIPTION
## Description

This PR reverts an alternation in the `google.config` file:
- The `google-lifesciences` has been defined as the executor when `google` profile is used. 
