### PR TITLE
Remove network and subnetwork from Google configs

### DIFF
--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -2,8 +2,6 @@ google {
     lifeSciences.bootDiskSize = params.gls_boot_disk_size
     lifeSciences.preemptible = params.gls_preemptible
     zone = params.zone
-    network = params.network
-    subnetwork = params.subnetwork
 }
 
 docker.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -81,8 +81,6 @@ params {
     gls_boot_disk_size = 50.GB
     gls_preemptible = true
     zone = 'us-east1-b'
-    network = 'jax-poc-lifebit-01-vpc-network'
-    subnetwork = 'us-east1-sub2'
     
     // process scope options
     echo = false


### PR DESCRIPTION
## Description

This PR removes the `google.network` and `google.subnetwork` parameters to allow CloudOS to set it automatically. Formerly this extra option was overwriting the CloudOS configuration, which was workspace specific. The change enables seamless usage of the same pipeline parameters set across google projects (and hence CloudOS workspaces) without the need to redefine the required `--network`  and `--subnetwork` which are not always known to the pipeline users.

## Changes

- [x] Removes `google.network` and `google.subnetwork` from [conf/executors/google.config](./conf/executors/google.config)
- [x] Removes the option to define   `network` and `subnetwork` via params eg `--network` --subnetwork` from [nextflow.config](./nextflow.config)


## How to test

To test, resume a previously completed CloudOS job that formerly was running with the added parameter flag-value pairs `--network xxx` `--subnetwork yyy`.

### 1. Resume and switch the branch to the current one named `fix-issues/301`
![](http://g.recordit.co/HCWjUtP7Ya.gif)

### 2. Remove the above options `--network xxx` `--subnetwork yyy`.
![](http://g.recordit.co/07pxq3zVzs.gif)


## Expected behaviour

The CloudOS job should be completed as it did before removing the options.
