### PR TITLE
Updates rmats version from 4.1.1->4.1.2

### DIFF
--- a/containers/rmats4/Dockerfile
+++ b/containers/rmats4/Dockerfile
@@ -1,15 +1,17 @@
-# continuumio/miniconda3:4.8.2
-FROM continuumio/miniconda3@sha256:456e3196bf3ffb13fee7c9216db4b18b5e6f4d37090b31df3e0309926e98cfe2
+# continuumio/miniconda3:4.12.0
+FROM continuumio/miniconda3@sha256:58b1c7df8d69655ffec017ede784a075e3c2e9feff0fc50ef65300fc75aa45ae
 
 LABEL authors="phil@lifebit.ai laura.urbanski@jax.org" \
 	description="Docker image containing rMATS v4.1.1"
 
+RUN conda install -c conda-forge mamba -y
+
 COPY environment.yml /
 RUN apt-get update && apt-get install -y procps && \
-	conda env create -f /environment.yml && conda clean -a
+	mamba env create -f /environment.yml && conda clean -a
 
 # Make RUN commands use the new environment:
 RUN echo "conda activate rmats4" >> ~/.bashrc
-SHELL ["/bin/bash", "--login", "-c"]	
+SHELL ["/bin/bash", "--login", "-c"]
 
 ENV PATH /opt/conda/envs/rmats4/bin:$PATH

--- a/containers/rmats4/environment.yml
+++ b/containers/rmats4/environment.yml
@@ -4,6 +4,6 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - rmats=4.1.1
+  - rmats=4.1.2
   - bioconductor-bsgenome.hsapiens.ucsc.hg38=1.4.1
   - bioconductor-bsgenome.mmusculus.ucsc.mm10=1.4.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -88,6 +88,7 @@ params {
     echo = false
 
     config = 'conf/executors/google.config'
+    rmats_container = 'anczukowlab/splicing-rmats:4.1.2'
 }
 
 cleanup = params.cleanup
@@ -117,16 +118,16 @@ process {
     container = 'anczukowlab/download_reads:2.0'
   }
   withName: 'rmats' {
-    container = 'anczukowlab/splicing-rmats:4.1.1'
+    container = params.rmats_container
   }
   withName: 'paired_rmats' {
-    container = 'anczukowlab/splicing-rmats:4.1.1'
+    container = params.rmats_container
   }
   withName: 'collect_tool_versions_env1' {
     container = 'anczukowlab/splicing-pipelines-nf:3.0'
   }
   withName: 'collect_tool_versions_env2' {
-    container = 'anczukowlab/splicing-rmats:4.1.1'
+    container = params.rmats_container
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -88,7 +88,7 @@ params {
     echo = false
 
     config = 'conf/executors/google.config'
-    rmats_container = 'quay.io/lifebitai/splicing-rmats:4.1.2'
+    rmats_container = 'anczukowlab/splicing-rmats:4.1.2'
 }
 
 cleanup = params.cleanup

--- a/nextflow.config
+++ b/nextflow.config
@@ -88,7 +88,7 @@ params {
     echo = false
 
     config = 'conf/executors/google.config'
-    rmats_container = 'anczukowlab/splicing-rmats:4.1.2'
+    rmats_container = 'quay.io/lifebitai/splicing-rmats:4.1.2'
 }
 
 cleanup = params.cleanup


### PR DESCRIPTION
This PR resolves https://github.com/TheJacksonLaboratory/splicing-pipelines-nf/issues/312 

To be able to test the pipeline, we would need the new docker image to be pushed to `anczukowlab/splicing-rmats:4.1.2`

To do so, @angarb can follow the steps below:

```
mkdir new-clean-folder
cd new-clean-folder
git clone https://github.com/TheJacksonLaboratory/splicing-pipelines-nf
cd splicing-pipelines-nf
git checkout updates-rmats-to-v4.1.2
cd containers/rmats4/
docker build -t anczukowlab/splicing-rmats:4.1.2 .
# username: anczukowlab password: <Brittany would know :) >
docker login

docker push anczukowlab/splicing-rmats:4.1.2
```