### PR TITLE
Update resource parameterisation

### DIFF
--- a/conf/executors/base.config
+++ b/conf/executors/base.config
@@ -46,6 +46,15 @@ process {
     memory = { check_max( 120.GB * task.attempt, 'memory' ) }
     time = { check_max( params.mega_time * task.attempt, 'time' ) }
   }
+
+  withName: 'rmats' {
+    cpus = { check_max (params.rmats_cpus, 'cpus')}
+    memory = { check_max( (params.rmats_memory as nextflow.util.MemoryUnit), 'memory' ) }
+  }
+  withName: 'stringtie_merge' {
+      cpus = {check_max(params.stringtie_merge_cpus * task.attempt, 'cpus')}
+      memory = {check_max( (params.stringtie_merge_memory as nextflow.util.MemoryUnit) * task.attempt, 'memory')}
+  }
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -73,8 +73,7 @@ process {
     withName: 'stringtie_merge' {
         disk = params.gc_disk_size
         cpus = {check_max(8 * task.attempt, 'cpus')}
-        memory = {check_max(30.GB * task.attempt, 'memory')}
-    }
+        memory = {check_max( (params.stringtie_merge_memory as nextflow.util.MemoryUnit) * task.attempt, 'memory')}    }
     withName: 'prep_de' {
         disk = params.gc_disk_size
         cpus = {check_max(8 * task.attempt, 'cpus')}

--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -72,8 +72,10 @@ process {
     }
     withName: 'stringtie_merge' {
         disk = params.gc_disk_size
-        cpus = {check_max(8 * task.attempt, 'cpus')}
-        memory = {check_max( (params.stringtie_merge_memory as nextflow.util.MemoryUnit) * task.attempt, 'memory')}    }
+        cpus = {check_max(params.stringtie_merge_cpus * task.attempt, 'cpus')}
+        memory = {check_max( (params.stringtie_merge_memory as nextflow.util.MemoryUnit) * task.attempt, 'memory')}
+        if (params.stringtie_merge_machine_type) { machineType = params.stringtie_merge_machine_type }
+    }
     withName: 'prep_de' {
         disk = params.gc_disk_size
         cpus = {check_max(8 * task.attempt, 'cpus')}

--- a/conf/executors/google.config
+++ b/conf/executors/google.config
@@ -83,8 +83,9 @@ process {
     }
     withName: 'rmats' {
         disk = params.gc_disk_size
-        cpus = { check_max (30 * task.attempt, 'cpus')}
-        memory = { check_max( 120.GB * task.attempt, 'memory' ) }
+        cpus = { check_max (params.rmats_cpus, 'cpus')}
+        memory = { check_max( (params.rmats_memory as nextflow.util.MemoryUnit), 'memory' ) }
+        if (params.rmats_machine_type) { machineType = params.rmats_machine_type }
     }
     withName: 'paired_rmats' {
         disk = params.gc_disk_size

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,6 +91,9 @@ Both of these should be specified without quotes
 Input files:
     --reads                     Path to reads.csv file, which specifies the sample_id and path to FASTQ files
                                 for each read or read pair (path).
+                When using the --download_from GTEX option the reads file must be a simple csv file listing
+                bam file names to be processed in the analysis. The input manifest will be downsampled
+                to only contain information about these files.
                                 This file is used if starting at beginning of pipeline. It can be file paths,
                                 s3 links or ftp link.
                                 (default: no reads.csv)
@@ -107,6 +110,8 @@ Input files:
                                 (string)
                                 false should be used to run local files on the HPC (Sumner).
                                 'TCGA' can also be used to download GDC data including HCMI data.
+                                (default: false)
+    --manifest                  Manifest file to download data from GTEX. (string)
                                 (default: false)
     --key_file                  For downloading reads, use TCGA authentication token (TCGA) or
                                 credentials.json file in case of 'GTEX'.
@@ -186,6 +191,19 @@ rMATS:
                                 (default: 50)
     --mel                       Maximum Exon Length. Only impacts --novelSS behavior (int)
                                 (default: 500)
+    --rmats_merge_memory          Sets base RAM requirement for stringtie_merge process.
+                                (default: 120.GB)
+    --rmats_merge_cpu             Sets base CPU requirement for stringtie_merge process.
+                                (default: 30)
+    --rmats_merge_machine_type    Only specific to google-cloud executor. Request a specific machine type for rmats.
+
+Stringtie:
+    --stringtie_merge_memory      Sets base RAM requirement for stringtie_merge process.
+                                (default: 30.GB)
+    --stringtie_merge_cpu         Sets base CPU requirement for stringtie_merge process.
+                                (default: 8)
+    --stringtie_merge_machine_type Only specific to google-cloud executor. Request a specific machine type 
+                                    for stringtie_merge.
 
 Other:
     --test                      For running trim test (bool)

--- a/main.nf
+++ b/main.nf
@@ -125,6 +125,19 @@ def helpMessage() {
                                     (default: 50)
       --mel                         Maximum Exon Length. Only impacts --novelSS behavior (int)
                                     (default: 500)
+      --rmats_merge_memory          Sets base RAM requirement for stringtie_merge process.
+                                    (default: 120.GB)
+      --rmats_merge_cpu             Sets base CPU requirement for stringtie_merge process.
+                                    (default: 30)
+      --rmats_merge_machine_type    Only specific to google-cloud executor. Request a specific machine type for rmats.
+
+    Stringtie:
+      --stringtie_merge_memory      Sets base RAM requirement for stringtie_merge process.
+                                    (default: 30.GB)
+      --stringtie_merge_cpu         Sets base CPU requirement for stringtie_merge process.
+                                    (default: 8)
+      --stringtie_merge_machine_type Only specific to google-cloud executor. Request a specific machine type 
+                                     for stringtie_merge.
 
     Other:
       --test                        For running trim test (bool)
@@ -150,8 +163,6 @@ def helpMessage() {
                                     (default: 20.h)
       --gc_disk_size                Only specific to google-cloud executor. Adds disk-space for few aggregative processes.
                                     (default: "200 GB" based on 100 samples. Simply add 2 x Number of Samples)
-      --stringtie_merge_memory      Only specific to google-cloud executor. Sets base RAM requirement for stringtie_merge process.
-                                    (default: 30.GB)
       --debug                       This option will enable echo of script execution into STDOUT with some additional
                                     resource information (such as machine type, memory, cpu and disk space)
                                     (default: false)

--- a/main.nf
+++ b/main.nf
@@ -150,6 +150,8 @@ def helpMessage() {
                                     (default: 20.h)
       --gc_disk_size                Only specific to google-cloud executor. Adds disk-space for few aggregative processes.
                                     (default: "200 GB" based on 100 samples. Simply add 2 x Number of Samples)
+      --stringtie_merge_memory      Only specific to google-cloud executor. Sets base RAM requirement for stringtie_merge process.
+                                    (default: 30.GB)
       --debug                       This option will enable echo of script execution into STDOUT with some additional
                                     resource information (such as machine type, memory, cpu and disk space)
                                     (default: false)
@@ -252,6 +254,7 @@ log.info "Mismatch                    : ${params.mismatch}"
 log.info "filterScore                 : ${params.filterScore}"
 log.info "sjdbOverhangMin             : ${params.sjdbOverhangMin}"
 log.info "STAR memory                 : ${params.star_memory ? star_memory : 'Not provided, Using STAR task max memory'}"
+log.info "stringtie merge memory      : ${params.stringtie_merge_memory}"
 log.info "Test                        : ${params.test}"
 log.info "Download from               : ${params.download_from ? params.download_from : 'FASTQs directly provided'}"
 log.info "Key file                    : ${params.key_file ? params.key_file : 'Not provided'}"

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,6 +52,10 @@ params {
     novelSS        = false
     mil            = 50
     mel            = 500
+    rmats_cpus     = 30
+    rmats_memory   = 120.GB
+    rmats_machine_type = false //not set by default
+
 
     // Stringtie
     stringtie_merge_cpus = 8

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,11 @@ params {
     novelSS        = false
     mil            = 50
     mel            = 500
+
+    // Stringtie
+    stringtie_merge_cpus = 8
     stringtie_merge_memory = 30.GB
+    stringtie_merge_machine_type = false //not set by default
 
     // Other
     test           = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,6 +52,7 @@ params {
     novelSS        = false
     mil            = 50
     mel            = 500
+    stringtie_merge_memory = 30.GB
 
     // Other
     test           = false


### PR DESCRIPTION
## Overview

Adds parameters to specifically control the resources requested for rMATS and StringTie. Address issue #311 .

## Changes

+ Adds the following parameters:
  + `--rmats_cpus`
  + `--rmats_memory`
  + `--rmats_machine_type` for setting machine type in GCP
  + `--stringtie_merge_cpus`
  + `--stringtie_merge_memory`
  + `--stringtie_merge_machine_type` for setting machine type in GCP
+ Update Readme with new parameter information