### PR TITLE
Implement process to detect strandedness of input RNAseq data

### DIFF
--- a/containers/strandedness/Dockerfile
+++ b/containers/strandedness/Dockerfile
@@ -1,0 +1,19 @@
+FROM continuumio/miniconda3@sha256:a2e6aa4cd0b6dd696ae9e3e5732943250a977ab3a42b2fe5fb7ef0c19d2d9f16
+LABEL description="Dockerfile containing all the requirements for strandedness detection" \
+      author="ines@lifebit.ai"
+
+ARG ENV_NAME="strandedness"
+
+RUN apk add --no-cache bash=5.0.17-r0 procps=3.3.16-r0
+
+COPY environment.yml /
+RUN conda env update -n ${ENV_NAME} -f environment.yml && conda clean -a
+
+# Add conda installation dir to PATH (instead of doing 'conda activate')
+ENV PATH /opt/conda/envs/${ENV_NAME}/bin:$PATH
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name ${ENV_NAME} > ${ENV_NAME}_exported.yml
+
+# Initialise bash for conda
+RUN conda init bash

--- a/containers/strandedness/environment.yml
+++ b/containers/strandedness/environment.yml
@@ -1,0 +1,11 @@
+name: strandedness
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+  - anaconda
+dependencies:
+  - rseqc=4.0.0
+  - kallisto=0.48.0
+  - samtools=1.15.1
+  - bedtools=2.30.0


### PR DESCRIPTION
## Description

This Pull Request aims to implement a chain of processes to determine the strandedness of the RNA-seq library being used. 
To do so, the following approach will be used:

1. subset input read files to first n reads (default n: 200000)
2. run [kallisto](https://pachterlab.github.io/kallisto/) pseudoalignment to produce BAM file
3. convert input GTF gene annotation file to bed12
4. run [RSeQC infer_experiment.py](http://rseqc.sourceforge.net/#infer-experiment-py) with produced BAM file and bed12 file
5. parse output to give value of strandedness as 'first-strand' , 'second-strand' or `false` according to RSeQC output 

## Added Features

[x] Add container with the necessary dependencies (`kallisto`, `RSeQC`, `bedtools`)