### PR TITLE
Add process to downsample reads before strandedness inference

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -54,6 +54,7 @@ params {
     mel            = 500
 
     // Other
+    downsample     = 0.1
     salmon_index   = false
     test           = false
     skiprMATS      = false
@@ -128,6 +129,9 @@ process {
   }
   withName: 'collect_tool_versions_env2' {
     container = 'anczukowlab/splicing-rmats:4.1.1'
+  }
+  withName: 'downsample' {
+    container = 'quay.io/lifebitai/seqkit:v1.0.0'
   }
   withName: 'infer_strandedness' {
     container = 'quay.io/lifebitai/salmon:1.9.0'


### PR DESCRIPTION
This PR improves #320 by adding an intermediate process to downsample reads before salmon mapping. 

A new parameter was added, `--downsample`, to control the proportion of reads to be retained. By default it's set to `0.1`. 